### PR TITLE
想定外の加速度が設定されることがある不具合の修正

### DIFF
--- a/src/inertia-state.ts
+++ b/src/inertia-state.ts
@@ -70,6 +70,8 @@ export class InertiaState {
     this.movement[1] = 0;
     this.velocity[0] = 0;
     this.velocity[1] = 0;
+    this.moveDelta[0] = 0;
+    this.moveDelta[1] = 0;
   }
 
   private updateVelocity() {


### PR DESCRIPTION
## バグ内容

特定の状況下で、想定外の加速度が設定されてしまうことがある

## 把握している再現方法

0. Mac のトラックパッドで `タップでクリック` を有効化する
1. https://leader22.github.io/inertia-state/ のデモページにアクセス
2. ボックスをドラッグして一旦ある程度の距離動かす
3. ボックス上のどこかを `タップでクリック` を使ってクリックする (2のドラッグ終了地点ではだめで少しだけマウスポインターを移動する必要がある)


https://user-images.githubusercontent.com/83202837/131460912-eb2161a6-6159-4b84-a5ca-3236c9721c66.mov



## 原理

- 一度 `start` / `update` / `stop` を経ると、 `moveDelta` に移動距離が保存されたままになる
- 上記の状態で `start` を実行すると、これをトリガーに呼ばれた最初の `updateVelocity` で `velocity` に想定外の大きな値が保存される
- 1/60 秒たつ前 (つまり次の `updateVelocity` が呼ばれる前) に `stop` を呼ぶとこの加速度を利用して `callback` 関数が呼ばれてしまう

## 対処方法

- `reset` 関数が呼ばれた際に、 `moveDelta` も `0` にすることで想定外の値を `velocity` に指定されなくする